### PR TITLE
General cleanup and runtime update

### DIFF
--- a/es.estoes.wallpaperDownloader.metainfo.xml
+++ b/es.estoes.wallpaperDownloader.metainfo.xml
@@ -2,13 +2,16 @@
 <component type="desktop-application">
   <id>es.estoes.wallpaperDownloader</id>
   <name>Wallpaper Downloader</name>
+  <launchable type="desktop-id">es.estoes.wallpaperDownloader.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-only</project_license>
   <developer_name>Eloy García Almadén</developer_name>
   <summary>Download, manage and change your wallpapers automatically from the Internet</summary>
   <summary xml:lang="es">Gestiona y descarga automáticamente fondos de pantalla desde Internet</summary>
   <summary xml:lang="pt_BR">Gerencia e baixa automaticamente papéis de parede da Internet</summary>
-  <description><p>Wallpaper Downloader can automatically download and set wallpapers for you. Supported sites include: DeviantArt, Wallhaven, Bing Daily Wallpaper, Social Wallpapering, WallpaperFusion, DualMonitorBackgrounds, Unsplash.</p></description>
+  <description>
+    <p>Wallpaper Downloader can automatically download and set wallpapers for you. Supported sites include: DeviantArt, Wallhaven, Bing Daily Wallpaper, Social Wallpapering, WallpaperFusion, DualMonitorBackgrounds, Unsplash.</p>
+  </description>
   <screenshots>
     <screenshot type="default">
       <caption>Providers tab</caption>

--- a/es.estoes.wallpaperDownloader.metainfo.xml
+++ b/es.estoes.wallpaperDownloader.metainfo.xml
@@ -39,10 +39,20 @@
   <url type="bugtracker">https://bitbucket.org/eloy_garcia_pca/wallpaperdownloader/issues?status=new&amp;status=open</url>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release date="2022-07-07" version="4.3"/>
-    <release date="2021-07-23" version="4.2"/>
-    <release date="2021-01-07" version="4.1"/>
-    <release date="2020-06-17" version="4.0"/>
-    <release date="2020-02-09" version="3.9"/>
+    <release version="4.3" date="2022-07-07">
+      <url>https://bitbucket.org/eloy_garcia_pca/wallpaperdownloader/wiki/Features#markdown-header-version-43</url>
+    </release>
+    <release version="4.2" date="2021-07-23">
+      <url>https://bitbucket.org/eloy_garcia_pca/wallpaperdownloader/wiki/Features#markdown-header-version-42</url>
+    </release>
+    <release version="4.1" date="2021-01-07">
+      <url>https://bitbucket.org/eloy_garcia_pca/wallpaperdownloader/wiki/Features#markdown-header-version-41</url>
+    </release>
+    <release version="4.0" date="2020-06-17">
+      <url>https://bitbucket.org/eloy_garcia_pca/wallpaperdownloader/wiki/Features#markdown-header-version-40</url>
+    </release>
+    <release version="3.9" date="2020-02-09">
+      <url>https://bitbucket.org/eloy_garcia_pca/wallpaperdownloader/wiki/Features#markdown-header-version-39</url>
+    </release>
   </releases>
 </component>

--- a/es.estoes.wallpaperDownloader.yaml
+++ b/es.estoes.wallpaperDownloader.yaml
@@ -36,6 +36,9 @@ modules:
       - install -Dm644 -t /app/share/metainfo $FLATPAK_ID.metainfo.xml
       - desktop-file-edit --set-icon=$FLATPAK_ID /app/share/applications/$FLATPAK_ID.desktop
       - desktop-file-edit --set-key=Exec --set-value=wallpaperdownloader /app/share/applications/$FLATPAK_ID.desktop
+      - desktop-file-edit --set-key=StartupNotify --set-value=true /app/share/applications/$FLATPAK_ID.desktop
+      - desktop-file-edit --set-key=StartupWMClass --set-value=es-estoes-wallpaperDownloader-Main
+        /app/share/applications/$FLATPAK_ID.desktop
     sources:
       - type: archive
         url: https://bitbucket.org/eloy_garcia_pca/wallpaperdownloader/get/v4.3.tar.gz

--- a/es.estoes.wallpaperDownloader.yaml
+++ b/es.estoes.wallpaperDownloader.yaml
@@ -41,12 +41,22 @@ modules:
         /app/share/applications/$FLATPAK_ID.desktop
     sources:
       - type: archive
+        dest-filename: wallpaperdownloader.tar.gz
         url: https://bitbucket.org/eloy_garcia_pca/wallpaperdownloader/get/v4.3.tar.gz
         sha256: 4537134f03eeb53ed5fbc2666dbf1f821cc445a905d5cf3626740b466f1c646e
+        x-checker-data:
+          is-main-source: true
+          type: json
+          url: https://api.bitbucket.org/2.0/repositories/eloy_garcia_pca/wallpaperdownloader/refs/tags?sort=-name
+          tag-query: .values | .[0].name
+          timestamp-query: .values | .[0].date
+          version-query: $tag | sub("^v"; "")
+          url-query: '"https://bitbucket.org/eloy_garcia_pca/wallpaperdownloader/get/\($tag).tar.gz"'
       - type: script
         dest-filename: wallpaperdownloader
         commands:
-          - exec java -Xmx256m -Xms128m -jar /app/share/es.estoes.wallpaperDownloader/wallpaperdownloader.jar $@
+          - exec java -Xmx256m -Xms128m -jar /app/share/es.estoes.wallpaperDownloader/wallpaperdownloader.jar
+            $@
       - type: file
         path: es.estoes.wallpaperDownloader.metainfo.xml
       - maven-dependencies.yaml

--- a/es.estoes.wallpaperDownloader.yaml
+++ b/es.estoes.wallpaperDownloader.yaml
@@ -1,10 +1,11 @@
 app-id: es.estoes.wallpaperDownloader
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk11
 command: wallpaperdownloader
+
 finish-args:
   - --share=network
   - --socket=x11

--- a/es.estoes.wallpaperDownloader.yaml
+++ b/es.estoes.wallpaperDownloader.yaml
@@ -24,11 +24,12 @@ modules:
     build-commands:
       - mvn clean package -DpackagingPhase=none
       - install -Dm755 -t /app/bin wallpaperdownloader
-      - install -Dm644 -t /app/share/es.estoes.wallpaperDownloader target/wallpaperdownloader.jar
-      - install -Dm644 deb/wallpaperdownloader.desktop /app/share/applications/es.estoes.wallpaperDownloader.desktop
-      - install -Dm644 deb/wallpaperdownloader.svg /app/share/icons/hicolor/scalable/apps/es.estoes.wallpaperDownloader.svg
-      - install -Dm644 -t /app/share/metainfo es.estoes.wallpaperDownloader.metainfo.xml
-      - desktop-file-edit --set-icon=es.estoes.wallpaperDownloader --set-key=Exec --set-value=wallpaperdownloader /app/share/applications/es.estoes.wallpaperDownloader.desktop
+      - install -Dm644 -t /app/share/$FLATPAK_ID target/wallpaperdownloader.jar
+      - install -Dm644 deb/wallpaperdownloader.desktop /app/share/applications/$FLATPAK_ID.desktop
+      - install -Dm644 deb/wallpaperdownloader.svg /app/share/icons/hicolor/scalable/apps/$FLATPAK_ID.svg
+      - install -Dm644 -t /app/share/metainfo $FLATPAK_ID.metainfo.xml
+      - desktop-file-edit --set-icon=$FLATPAK_ID /app/share/applications/$FLATPAK_ID.desktop
+      - desktop-file-edit --set-key=Exec --set-value=wallpaperdownloader /app/share/applications/$FLATPAK_ID.desktop
     sources:
       - type: archive
         url: https://bitbucket.org/eloy_garcia_pca/wallpaperdownloader/get/v4.3.tar.gz

--- a/es.estoes.wallpaperDownloader.yaml
+++ b/es.estoes.wallpaperDownloader.yaml
@@ -13,7 +13,13 @@ finish-args:
   - --env=JAVA_HOME=/app/jre
   - --filesystem=~/.wallpaperdownloader:create
   - --talk-name=org.freedesktop.Flatpak
+
 modules:
+  - name: openjdk
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/openjdk11/install.sh
+
   - name: wallpaperdownloader
     buildsystem: simple
     build-options:
@@ -41,8 +47,3 @@ modules:
       - type: file
         path: es.estoes.wallpaperDownloader.metainfo.xml
       - maven-dependencies.yaml
-    modules:
-      - name: openjdk
-        buildsystem: simple
-        build-commands:
-          - /usr/lib/sdk/openjdk11/install.sh


### PR DESCRIPTION
- ee26694916e4b58cfa58e3bfa11594568f5987e3: Use `$FLATPAK_ID` where possible
- ad1ad70319ae503e331c55d64bb9cac2c5bf285d: Move the `openjdk` module at the top
- b9e24822729907c1ebb767ebc641afc9f2f277ff: Add `StartupNotify`/`StartupWMClass` to the desktop file
- 5623273ee5bb54a21915b2505c8ef79bd5603b6e: Add data checker
- 04fc9378748b54dbc8caf0e59d8c017fbb90d1a6: Add `launchable` tag to appstream file
- 263391566edb80276deecc34fc2c7cd2a0378384: Link release notes for all versions
- c7869e59fb9d5ce542b60fb6dd809c5a7c17eaf0: Update runtime to 23.08