### PR TITLE
Add xrandr for XFCE4 / Update to version 4.4.2

### DIFF
--- a/es.estoes.wallpaperDownloader.yaml
+++ b/es.estoes.wallpaperDownloader.yaml
@@ -21,6 +21,20 @@ modules:
     build-commands:
       - /usr/lib/sdk/openjdk11/install.sh
 
+  - name: xrandr
+    sources:
+      - type: archive
+        url: https://xorg.freedesktop.org/archive/individual/app/xrandr-1.5.2.tar.xz
+        sha256: c8bee4790d9058bacc4b6246456c58021db58a87ddda1a9d0139bf5f18f1f240
+        x-checker-data:
+          type: anitya
+          project-id: 14957
+          stable-only: true
+          url-template: https://xorg.freedesktop.org/archive/individual/app/xrandr-$version.tar.xz
+    cleanup:
+      - /share/man
+      - /bin/xkeystone
+
   - name: wallpaperdownloader
     buildsystem: simple
     build-options:

--- a/es.estoes.wallpaperDownloader.yaml
+++ b/es.estoes.wallpaperDownloader.yaml
@@ -57,8 +57,8 @@ modules:
     sources:
       - type: archive
         dest-filename: wallpaperdownloader.tar.gz
-        url: https://bitbucket.org/eloy_garcia_pca/wallpaperdownloader/get/v4.4.1.tar.gz
-        sha256: 59daf34b0b4acfe95a1978e0131099a5035a47f8a4695ec1b85a076e5abd1339
+        url: https://bitbucket.org/eloy_garcia_pca/wallpaperdownloader/get/v4.4.2.tar.gz
+        sha256: 02bcc6f14961b071ff4add31b1ad986c57ebdaaab1b7c9f4ebb9913c004cda02
         x-checker-data:
           type: json
           url: https://api.bitbucket.org/2.0/repositories/eloy_garcia_pca/wallpaperdownloader/refs/tags?sort=-name

--- a/maven-dependencies.yaml
+++ b/maven-dependencies.yaml
@@ -247,6 +247,10 @@
   url: https://repo.maven.apache.org/maven2/org/apache/apache/29/apache-29.pom
   sha256: 3e49037174820bbd0df63420a977255886398954c2a06291fa61f727ac35b377
 - type: file
+  dest: .m2/repository/org/apache/apache/30
+  url: https://repo.maven.apache.org/maven2/org/apache/apache/30/apache-30.pom
+  sha256: 63dd4a393a9c0dfcb314efe83871a41d243bc8d200cbc7f2d197f30da78239d8
+- type: file
   dest: .m2/repository/org/apache/commons/commons-compress/1.11
   url: https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.11/commons-compress-1.11.jar
   sha256: 9fc905a68dcf3038d4866a54040706998e0202a34ecd95d734e819b0bccf439e
@@ -599,6 +603,10 @@
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/39/maven-parent-39.pom
   sha256: cfe4820aa1d96ae51d1dc5b0e2a9dc582c42478c24c95ca8238f547e60bef721
 - type: file
+  dest: .m2/repository/org/apache/maven/maven-parent/40
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/40/maven-parent-40.pom
+  sha256: 17349590a6387e195dbb21c9556aa5721f37738d2b4b810a923bf1005be5290a
+- type: file
   dest: .m2/repository/org/apache/maven/maven-plugin-api/2.0.7
   url: https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.7/maven-plugin-api-2.0.7.jar
   sha256: 1bf733ee1d2716d8b9f1e987452a55a16c0e8c443649e6e679ee337831d15602
@@ -847,13 +855,13 @@
   url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/3.3.1/maven-resources-plugin-3.3.1.pom
   sha256: 3269d0a6e3cd614a29486f57fc86488b0f1e458a11bebc61f9408fd6c7cf85ae
 - type: file
-  dest: .m2/repository/org/apache/maven/plugins/maven-surefire-plugin/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.1.2/maven-surefire-plugin-3.1.2.jar
-  sha256: 079f1ce924197890598b651f515b8337261cb37a0714341ed5ff5b312736b316
+  dest: .m2/repository/org/apache/maven/plugins/maven-surefire-plugin/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.2.2/maven-surefire-plugin-3.2.2.jar
+  sha256: fc1e5c8d637337551dac8c47a6f7a89a0e912b34d9dca781463c54ff89c51504
 - type: file
-  dest: .m2/repository/org/apache/maven/plugins/maven-surefire-plugin/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.1.2/maven-surefire-plugin-3.1.2.pom
-  sha256: af6b01b48de15f2d4ded1e3884a0fdfd2deb4ef0156dccc6a2bfc13d3952c4ff
+  dest: .m2/repository/org/apache/maven/plugins/maven-surefire-plugin/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/3.2.2/maven-surefire-plugin-3.2.2.pom
+  sha256: 096f9552ee3f7b54bded9ec96fc841ca4eca55ee6b39aeaf83730fb2612119e7
 - type: file
   dest: .m2/repository/org/apache/maven/reporting/maven-reporting-api/2.0.7
   url: https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.7/maven-reporting-api-2.0.7.jar
@@ -1027,93 +1035,93 @@
   url: https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.3.4/maven-shared-utils-3.3.4.pom
   sha256: bf83482d96f76d63699d63e125e64f4ac73c8178985733662dbd69af9c60339e
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/common-java5/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.1.2/common-java5-3.1.2.jar
-  sha256: fa78f56b5144d602c56c102a8f3456af855a4c7562b378aaf9ed4a423b291044
+  dest: .m2/repository/org/apache/maven/surefire/common-java5/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.2.2/common-java5-3.2.2.jar
+  sha256: 97ad4c16be3dbc34d0f5658c690eeadce27bf177518a46ee0fe8452ed7d6836e
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/common-java5/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.1.2/common-java5-3.1.2.pom
-  sha256: be42c50e6555d906b14ff0bdec92ccdf91624a6ef6d91ddd41ed591a8f3b72c8
+  dest: .m2/repository/org/apache/maven/surefire/common-java5/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-java5/3.2.2/common-java5-3.2.2.pom
+  sha256: f5316db5054708efceaa9f6509668265e389fd5672e0bb32d88e6e2c5d9d767e
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/common-junit3/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-junit3/3.1.2/common-junit3-3.1.2.jar
-  sha256: 7b83fbdd034c5af1366fc12aefeb549deb77b256d3b6d2647c7375e99307c4df
+  dest: .m2/repository/org/apache/maven/surefire/common-junit3/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-junit3/3.2.2/common-junit3-3.2.2.jar
+  sha256: a7d814fcd4ef6ed4ed86176d0d2651a805a4a5f81243368ae0fcb5c666dcbc8c
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/common-junit3/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-junit3/3.1.2/common-junit3-3.1.2.pom
-  sha256: 47acf3b60507b4f3c592c20854179be7f9df32162bd7d515f5e1a8223b923afe
+  dest: .m2/repository/org/apache/maven/surefire/common-junit3/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/common-junit3/3.2.2/common-junit3-3.2.2.pom
+  sha256: a6b635e6c9146ca0ff19742771787c8f46446cf45161e4208c99823233099780
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/maven-surefire-common/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.1.2/maven-surefire-common-3.1.2.jar
-  sha256: 5bb2064768d1cba920f19b1f8eb0cfd3b6c346a7020615552a3c9dc8b175cdc0
+  dest: .m2/repository/org/apache/maven/surefire/maven-surefire-common/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.2.2/maven-surefire-common-3.2.2.jar
+  sha256: be29879c7fd69d1ae225dce241524992046b270d84cf125bb372ebf62cf8762d
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/maven-surefire-common/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.1.2/maven-surefire-common-3.1.2.pom
-  sha256: 9ed362fce12a3ff9709d4225d86e8c182db76d27f166f5e5211d742b128da51e
+  dest: .m2/repository/org/apache/maven/surefire/maven-surefire-common/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/3.2.2/maven-surefire-common-3.2.2.pom
+  sha256: d5241f819eceb173740f7e1fc40c3a05d6461fffcca45be160b3d5e928bd4913
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-api/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.1.2/surefire-api-3.1.2.jar
-  sha256: f62aeef7eb34196c9f4a7642cd610e4f175a88c040246918b19e4c3fbc0b8098
+  dest: .m2/repository/org/apache/maven/surefire/surefire-api/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.2.2/surefire-api-3.2.2.jar
+  sha256: cf3de8d5b3ea31b410be4957a3b2e9d0aba00ac4c321a8794d7eb5e3d548d705
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-api/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.1.2/surefire-api-3.1.2.pom
-  sha256: 002dd542501d89246aeb5b482d5bcbdcdb789cb6a36a22704d3524192f63ff09
+  dest: .m2/repository/org/apache/maven/surefire/surefire-api/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/3.2.2/surefire-api-3.2.2.pom
+  sha256: 3838aaff677f89d2bbef950ff0d921368c304e911efe2d3779db9ccbb226dbea
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-booter/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.1.2/surefire-booter-3.1.2.jar
-  sha256: 6d80b060de7e395e07bf90f9a14add0f80425add4016c89d7df91c9062717a20
+  dest: .m2/repository/org/apache/maven/surefire/surefire-booter/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.2.2/surefire-booter-3.2.2.jar
+  sha256: 57b6d9d56b9b48d767b87c43d3e8d673026c0181ff7cc30b96880779c5fdb74c
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-booter/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.1.2/surefire-booter-3.1.2.pom
-  sha256: 468ddd2df93670b14b2258a3da80a9e2b49205f199d4a6185a12907207114655
+  dest: .m2/repository/org/apache/maven/surefire/surefire-booter/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/3.2.2/surefire-booter-3.2.2.pom
+  sha256: 1a208e49222337b551c8c568497e33191cb3c45da45da8f4aec44ea3ec76ff3e
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-api/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.1.2/surefire-extensions-api-3.1.2.jar
-  sha256: 04fd7a32335a7898272c1b543da116f93be684a13920c8a64f7ec7df88a85860
+  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-api/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.2.2/surefire-extensions-api-3.2.2.jar
+  sha256: c17a663985b0cac17eb978488d3f0e62bfa649f0eff1c6411c25f5cda0a11cdc
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-api/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.1.2/surefire-extensions-api-3.1.2.pom
-  sha256: 0baf22d7475efbc70b2fa31f3d827848043ecc8adaf77c914ef3afd9193e1a23
+  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-api/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-api/3.2.2/surefire-extensions-api-3.2.2.pom
+  sha256: 3109ca4a113443dacd287ff3f9ddcf975f935d1a2881d259f1195ac28107ea86
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-spi/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.1.2/surefire-extensions-spi-3.1.2.jar
-  sha256: 512967d34539859e403cf489e8ba3ac7fc7648b5bdca44e1a81ca1312a78d6b3
+  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-spi/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.2.2/surefire-extensions-spi-3.2.2.jar
+  sha256: 38282f5e09ba6a129b22f5586c2d35c133461c0aa172d97e2f3a7c29293d1410
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-spi/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.1.2/surefire-extensions-spi-3.1.2.pom
-  sha256: 79cf2bac9ae8027e31535ed6c238b0ed6f60fa3d3ebfdf6af475a4dadeb14bbe
+  dest: .m2/repository/org/apache/maven/surefire/surefire-extensions-spi/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-extensions-spi/3.2.2/surefire-extensions-spi-3.2.2.pom
+  sha256: 502eb631385be00cc1dda7ad5abe06fc68fc7ebb34b73d735d0e27801379fc63
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-junit3/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit3/3.1.2/surefire-junit3-3.1.2.jar
-  sha256: 44c9d99facd75fc20c56ff7625179cbc0155574bfb435191e5882184d3a06896
+  dest: .m2/repository/org/apache/maven/surefire/surefire-junit3/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit3/3.2.2/surefire-junit3-3.2.2.jar
+  sha256: 10360a5a84ca524bb25f8c72a98be27006e3bd8064ae043ca1b802999ef77d18
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-junit3/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit3/3.1.2/surefire-junit3-3.1.2.pom
-  sha256: 95b9bb2218edd5f489bc10058c830b0f9bc1dfc30dbb1a76c29fd1ec9f4b5263
+  dest: .m2/repository/org/apache/maven/surefire/surefire-junit3/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit3/3.2.2/surefire-junit3-3.2.2.pom
+  sha256: d7625ca38c048934c8d3ae0a2b481b71db25141f4c364fcc9597887170dbef68
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-logger-api/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.1.2/surefire-logger-api-3.1.2.jar
-  sha256: 902ad97f07a0957b08661e4d3a27073275aef90d4413bed267a9ba0157ee3c0d
+  dest: .m2/repository/org/apache/maven/surefire/surefire-logger-api/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.2.2/surefire-logger-api-3.2.2.jar
+  sha256: 34ea28b6f8a822402b6bfa7046341c6258cc44a6f071b6066a3de926180c06b9
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-logger-api/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.1.2/surefire-logger-api-3.1.2.pom
-  sha256: 4705fd2764a791b30dd1a82af8c08cbf0e54519eb3dc451efdbeaaa27a565ba6
+  dest: .m2/repository/org/apache/maven/surefire/surefire-logger-api/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-logger-api/3.2.2/surefire-logger-api-3.2.2.pom
+  sha256: 5e7b3a29c8f31660334cd15fee1b10edb4e89289df90b2ff68adca83a5b8590e
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-providers/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-providers/3.1.2/surefire-providers-3.1.2.pom
-  sha256: 4a9550696d94946b6b3ea08bcb8cd03c9579c7514c86055d2dd1a31d29d66076
+  dest: .m2/repository/org/apache/maven/surefire/surefire-providers/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-providers/3.2.2/surefire-providers-3.2.2.pom
+  sha256: 11dbcb3c003f655fb8a40c922fbb7819babc3457825d1158cbf33068c6a19191
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-shared-utils/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.1.2/surefire-shared-utils-3.1.2.jar
-  sha256: b4a96b898513b73cdd96947cd080b3f3acbbd6126720ede9e075a0eb2d346d03
+  dest: .m2/repository/org/apache/maven/surefire/surefire-shared-utils/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.2.2/surefire-shared-utils-3.2.2.jar
+  sha256: f51e0ff777d36dd567cb7d129f8579ea7c2da03b4e81ef983e608bb4e11a200e
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire-shared-utils/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.1.2/surefire-shared-utils-3.1.2.pom
-  sha256: 9ddf5d8882837bb6e96db62671b979d842749a22f137b6e1124783d16840fabb
+  dest: .m2/repository/org/apache/maven/surefire/surefire-shared-utils/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-shared-utils/3.2.2/surefire-shared-utils-3.2.2.pom
+  sha256: 844db1db111a8b4c69f6b827206ba8fd077c3cd97eeacbe219a3f88a62dc7c83
 - type: file
-  dest: .m2/repository/org/apache/maven/surefire/surefire/3.1.2
-  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/3.1.2/surefire-3.1.2.pom
-  sha256: 75fe6bcd0e2b3da248bf55a3973fbd79cde29a6a80a02f9ad1fdf5593096bb60
+  dest: .m2/repository/org/apache/maven/surefire/surefire/3.2.2
+  url: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/3.2.2/surefire-3.2.2.pom
+  sha256: 06c9577ded19c01e045c37d8dbc290915aaedf3cde42b98134f6757f7d0d9cde
 - type: file
   dest: .m2/repository/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2
   url: https://repo.maven.apache.org/maven2/org/apache/maven/wagon/wagon-provider-api/1.0-beta-2/wagon-provider-api-1.0-beta-2.jar
@@ -1186,6 +1194,10 @@
   dest: .m2/repository/org/codehaus/plexus/plexus-classworlds/2.5.2
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.pom
   sha256: 89811897b815beefa094c39b4603e3f60c42276a2cd5d80b924ab19183629925
+- type: file
+  dest: .m2/repository/org/codehaus/plexus/plexus-classworlds/2.6.0
+  url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.pom
+  sha256: 469a6c59f92effa62c0797ce7d52d2c03cf8ee1034b923c360dd78a9f505a7ba
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-compilers/2.8.4
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compilers/2.8.4/plexus-compilers-2.8.4.pom
@@ -1263,6 +1275,10 @@
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.pom
   sha256: a909a0cbe292e54122b6b785f6924ab2f09b1630b7889c800e099e2627f91a78
 - type: file
+  dest: .m2/repository/org/codehaus/plexus/plexus-component-annotations/2.1.0
+  url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/2.1.0/plexus-component-annotations-2.1.0.pom
+  sha256: 0670b605255f7dc9a454daaec7912918ccf1b5475cbfca374363b51fcfd4ea00
+- type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-containers/1.0.3
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0.3/plexus-containers-1.0.3.pom
   sha256: 7c75075badcb014443ee94c8c4cad2f4a9905be3ce9430fe7b220afc7fa3a80f
@@ -1278,6 +1294,10 @@
   dest: .m2/repository/org/codehaus/plexus/plexus-containers/1.7.1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.7.1/plexus-containers-1.7.1.pom
   sha256: 5566a0bb51dc994c0350206608c7b4cdcc9b66881497bab56a32c42edca53e79
+- type: file
+  dest: .m2/repository/org/codehaus/plexus/plexus-containers/2.1.0
+  url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/2.1.0/plexus-containers-2.1.0.pom
+  sha256: 94d5aedb3c46023265396527cf8ce7fc944b7bd79e4ebab907386418eb5a08d7
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar
@@ -1371,21 +1391,21 @@
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/0.9.10/plexus-java-0.9.10.pom
   sha256: b0013096156cbb98dba97c2b0b07be194d33208b5bde7ee8866e69355e9ebd86
 - type: file
-  dest: .m2/repository/org/codehaus/plexus/plexus-java/1.1.2
-  url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.1.2/plexus-java-1.1.2.jar
-  sha256: 83659e0d3fa0eda61dc4e8d78ea5a5fe05b7985f88b8557716c295409e64b7f5
+  dest: .m2/repository/org/codehaus/plexus/plexus-java/1.2.0
+  url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.2.0/plexus-java-1.2.0.jar
+  sha256: 4d2d63cdcad46feba432110ef64bcdc8f8fad48538fda5cd2253686b45a94304
 - type: file
-  dest: .m2/repository/org/codehaus/plexus/plexus-java/1.1.2
-  url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.1.2/plexus-java-1.1.2.pom
-  sha256: 1c36ab1098026165a9cd6d18732d58da95adab6aa25938d472fa9c4a9498f944
+  dest: .m2/repository/org/codehaus/plexus/plexus-java/1.2.0
+  url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-java/1.2.0/plexus-java-1.2.0.pom
+  sha256: d069564d4f490ae22ad885dd4b3ab9ac33a27e23a6f8542760970a36935ccf42
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-languages/0.9.10
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/0.9.10/plexus-languages-0.9.10.pom
   sha256: 863adcfb4eaec8286de72e606c9cb39d65b0473309c41a2e7d37983291a10ba3
 - type: file
-  dest: .m2/repository/org/codehaus/plexus/plexus-languages/1.1.2
-  url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/1.1.2/plexus-languages-1.1.2.pom
-  sha256: 80a4d664695b082900c34aea241a73dd704288805efb88b25caebd3eead02079
+  dest: .m2/repository/org/codehaus/plexus/plexus-languages/1.2.0
+  url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-languages/1.2.0/plexus-languages-1.2.0.pom
+  sha256: a28f034d79815cd7a4b107f66182c21ebf45fbb2fbe2c15697860b720c8a3bf7
 - type: file
   dest: .m2/repository/org/codehaus/plexus/plexus-utils/1.0.4
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.0.4/plexus-utils-1.0.4.pom
@@ -1479,6 +1499,10 @@
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.pom
   sha256: 94ff68edeb48204d12c99189c767164d3a9f778a1372d1dce11a41462e6236f2
 - type: file
+  dest: .m2/repository/org/codehaus/plexus/plexus-utils/4.0.0
+  url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/4.0.0/plexus-utils-4.0.0.pom
+  sha256: a44c5479426dea0e7bfffd2ec3adf49c68515019788965c4d231fc3f04da4129
+- type: file
   dest: .m2/repository/org/codehaus/plexus/plexus/1.0.4
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.4/plexus-1.0.4.pom
   sha256: 2242fd02d12b1ca73267fb3d89863025517200e7a4ee426cba4667d0172c74c3
@@ -1535,6 +1559,14 @@
   url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/10/plexus-10.pom
   sha256: bba9c521064b9ca132ce97cc1cc7eb4afc2dbe32bc88cb872c88e99f6162301f
 - type: file
+  dest: .m2/repository/org/codehaus/plexus/plexus/13
+  url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/13/plexus-13.pom
+  sha256: 575945dc08966c66eb03d5bae9135bd22ca3920a1865bb99d3ecd93bef55abd3
+- type: file
+  dest: .m2/repository/org/codehaus/plexus/plexus/15
+  url: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/15/plexus-15.pom
+  sha256: 96dc0fbe73664a0f05c6770910473c1a12e1c112cb648364fca867daa689c21d
+- type: file
   dest: .m2/repository/org/easymock/easymock/2.4
   url: https://repo.maven.apache.org/maven2/org/easymock/easymock/2.4/easymock-2.4.jar
   sha256: 7c48d8ba6e070409f65a45afc4904824b7702598ab0bec273cdd0ce6f4c2c64f
@@ -1579,21 +1611,21 @@
   url: https://repo.maven.apache.org/maven2/org/eclipse/platform/org.eclipse.swt.gtk.linux.x86_64/3.116.100/org.eclipse.swt.gtk.linux.x86_64-3.116.100.pom
   sha256: cffbbe335b7f2bf45c5807c629900233cea326fb01535a307f07235269813267
 - type: file
-  dest: .m2/repository/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.5
-  url: https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.5/org.eclipse.sisu.inject-0.3.5.pom
-  sha256: c2976972b4242ffd8604716d8475f56755da0fa28618344ec4e5327810696d71
+  dest: .m2/repository/org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M2
+  url: https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M2/org.eclipse.sisu.inject-0.9.0.M2.pom
+  sha256: 05666f27941117ccadfab6329118c1c348f8b838ce89ed23182c151cb2943ee9
 - type: file
-  dest: .m2/repository/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.5
-  url: https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.5/org.eclipse.sisu.plexus-0.3.5.pom
-  sha256: 786523c9d78258a74aa13447a1676c2172acfdf432165d7adae2b7876d2d83d3
+  dest: .m2/repository/org/eclipse/sisu/org.eclipse.sisu.plexus/0.9.0.M2
+  url: https://repo.maven.apache.org/maven2/org/eclipse/sisu/org.eclipse.sisu.plexus/0.9.0.M2/org.eclipse.sisu.plexus-0.9.0.M2.pom
+  sha256: 8feb5693e2d2b2379f9f9f483f2d2b47ab54f0f0ed22cb232e968c544f778752
 - type: file
-  dest: .m2/repository/org/eclipse/sisu/sisu-inject/0.3.5
-  url: https://repo.maven.apache.org/maven2/org/eclipse/sisu/sisu-inject/0.3.5/sisu-inject-0.3.5.pom
-  sha256: 5f32ecab9c8f6dff1f9e41b853e40d8f23a2508219154ef67cc00d4556f5f5dd
+  dest: .m2/repository/org/eclipse/sisu/sisu-inject/0.9.0.M2
+  url: https://repo.maven.apache.org/maven2/org/eclipse/sisu/sisu-inject/0.9.0.M2/sisu-inject-0.9.0.M2.pom
+  sha256: 7630f4cd4d1620067fa83e1d748b012cffa0655e5380cc0e4a5e283d3b441fdb
 - type: file
-  dest: .m2/repository/org/eclipse/sisu/sisu-plexus/0.3.5
-  url: https://repo.maven.apache.org/maven2/org/eclipse/sisu/sisu-plexus/0.3.5/sisu-plexus-0.3.5.pom
-  sha256: 6eba0902efd899aec0d8d19ac3cbc53123cd41139fe0e1d29cc5c874a791b9de
+  dest: .m2/repository/org/eclipse/sisu/sisu-plexus/0.9.0.M2
+  url: https://repo.maven.apache.org/maven2/org/eclipse/sisu/sisu-plexus/0.9.0.M2/sisu-plexus-0.9.0.M2.pom
+  sha256: ec6e99407036014f81a39d81c56ba40d924c72d96e402ad14f7efd29b2c775cd
 - type: file
   dest: .m2/repository/org/hamcrest/hamcrest-core/1.1
   url: https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.1/hamcrest-core-1.1.pom
@@ -1635,6 +1667,14 @@
   url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.2/junit-bom-5.9.2.pom
   sha256: 2ed07d65845131f5336a86476c9a4056b59d0b58b9815ab3679bb0f36f35f705
 - type: file
+  dest: .m2/repository/org/junit/junit-bom/5.9.3
+  url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.3/junit-bom-5.9.3.pom
+  sha256: 4d0329cd9e72f2420e5ca15724cbfe6ffa6e5fd2888361516271190fdc342ed7
+- type: file
+  dest: .m2/repository/org/junit/junit-bom/5.10.0
+  url: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.10.0/junit-bom-5.10.0.pom
+  sha256: e006dd8894f9fc7b75fc32bb12fe5ed8be65667d5b454f99e2e0b8c5bb8d30b3
+- type: file
   dest: .m2/repository/org/jvnet/hudson/svnkit/svnkit/1.1.4-hudson-4
   url: https://repo.maven.apache.org/maven2/org/jvnet/hudson/svnkit/svnkit/1.1.4-hudson-4/svnkit-1.1.4-hudson-4.jar
   sha256: 9011e3f48fba7e51b71b0812a04f50e8dd6baa68b09c148bec6b365b1845b893
@@ -1667,13 +1707,13 @@
   url: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/6.2/asm-6.2.pom
   sha256: 92ec633f93f9c84dcb087a79df1395cfef07be574076ceaeb3159e096b4d4643
 - type: file
-  dest: .m2/repository/org/ow2/asm/asm/9.4
-  url: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.4/asm-9.4.jar
-  sha256: 39d0e2b3dc45af65a09b097945750a94a126e052e124f93468443a1d0e15f381
+  dest: .m2/repository/org/ow2/asm/asm/9.6
+  url: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.6/asm-9.6.jar
+  sha256: 3c6fac2424db3d4a853b669f4e3d1d9c3c552235e19a319673f887083c2303a1
 - type: file
-  dest: .m2/repository/org/ow2/asm/asm/9.4
-  url: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.4/asm-9.4.pom
-  sha256: 483751e48fb2d1f43c61ad3ab00ffa466edc0333d8fc2fdb5a26e95d32982394
+  dest: .m2/repository/org/ow2/asm/asm/9.6
+  url: https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.6/asm-9.6.pom
+  sha256: 92eee24bc3c843e4881d46c1dd6505471ee3142facfb466b428cfea5a56c6b60
 - type: file
   dest: .m2/repository/org/ow2/ow2/1.5.1
   url: https://repo.maven.apache.org/maven2/org/ow2/ow2/1.5.1/ow2-1.5.1.pom


### PR DESCRIPTION
When on a XFCE4 desktop, `xrandr` is used to get a list of connected display IDs, and these IDs are later used when invoking `xfconf-query`.

This also bumps Wallpaper Downloader to version 4.4.2.

@egara Can you please test this? Thank you.